### PR TITLE
`data_table`: Code `override_file` as an array-of-objects

### DIFF
--- a/FMS/data_table.json
+++ b/FMS/data_table.json
@@ -33,34 +33,40 @@
                   "enum": ["bilinear", "bicubic", "none"]
                 },
                 "multi_file": {
-                  "type": "object",
-                  "properties": {
-                    "next_file_name": {
-                      "type": "string",
-                      "minLength": 1
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "next_file_name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "prev_file_name": {
+                        "type": "string",
+                        "minLength": 1
+                      }
                     },
-                    "prev_file_name": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  },
-                  "required": ["next_file_name", "prev_file_name"],
-                  "additionalProperties": false
+                    "required": ["next_file_name", "prev_file_name"],
+                    "additionalProperties": false
+                  }
                 },
                 "external_weights": {
-                  "type": "object",
-                  "properties": {
-                    "file_name": {
-                      "type": "string",
-                      "minLength": 1
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "file_name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "source": {
+                        "type": "string",
+                        "minLength": 1
+                      }
                     },
-                    "source": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  },
-                  "required": ["file_name", "source"],
-                  "additionalProperties": false
+                    "required": ["file_name", "source"],
+                    "additionalProperties": false
+                  }
                 }
               },
               "required": ["file_name", "fieldname_in_file", "interp_method"],
@@ -71,27 +77,30 @@
             "type": "number"
           },
           "subregion": {
-            "type": "object",
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": ["inside_region", "outside_region"]
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["inside_region", "outside_region"]
+                },
+                "lon_start": {
+                  "type": "number"
+                },
+                "lon_end": {
+                  "type": "number"
+                },
+                "lat_start": {
+                  "type": "number"
+                },
+                "lat_end": {
+                  "type": "number"
+                }
               },
-              "lon_start": {
-                "type": "number"
-              },
-              "lon_end": {
-                "type": "number"
-              },
-              "lat_start": {
-                "type": "number"
-              },
-              "lat_end": {
-                "type": "number"
-              }
-            },
-            "required": ["type", "lon_start", "lon_end", "lat_start", "lat_end"],
-            "additionalProperties": false
+              "required": ["type", "lon_start", "lon_end", "lat_start", "lat_end"],
+              "additionalProperties": false
+            }
           }
         },
         "required": ["grid_name", "fieldname_in_model", "factor"],

--- a/FMS/data_table.json
+++ b/FMS/data_table.json
@@ -16,53 +16,56 @@
             "minLength": 1
           },
           "override_file": {
-            "type": "object",
-            "properties": {
-              "file_name": {
-                "type": "string",
-                "minLength": 1
-              },
-              "fieldname_in_file": {
-                "type": "string",
-                "minLength": 1
-              },
-              "interp_method": {
-                "type": "string",
-                "enum": ["bilinear", "bicubic", "none"]
-              },
-              "multi_file": {
-                "type": "object",
-                "properties": {
-                  "next_file_name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "prev_file_name": {
-                    "type": "string",
-                    "minLength": 1
-                  }
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "file_name": {
+                  "type": "string",
+                  "minLength": 1
                 },
-                "required": ["next_file_name", "prev_file_name"],
-                "additionalProperties": false
-              },
-              "external_weights": {
-                "type": "object",
-                "properties": {
-                  "file_name": {
-                    "type": "string",
-                    "minLength": 1
-                  },
-                  "source": {
-                    "type": "string",
-                    "minLength": 1
-                  }
+                "fieldname_in_file": {
+                  "type": "string",
+                  "minLength": 1
                 },
-                "required": ["file_name", "source"],
-                "additionalProperties": false
-              }
-            },
-            "required": ["file_name", "fieldname_in_file", "interp_method"],
-            "additionalProperties": false
+                "interp_method": {
+                  "type": "string",
+                  "enum": ["bilinear", "bicubic", "none"]
+                },
+                "multi_file": {
+                  "type": "object",
+                  "properties": {
+                    "next_file_name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "prev_file_name": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["next_file_name", "prev_file_name"],
+                  "additionalProperties": false
+                },
+                "external_weights": {
+                  "type": "object",
+                  "properties": {
+                    "file_name": {
+                      "type": "string",
+                      "minLength": 1
+                    },
+                    "source": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": ["file_name", "source"],
+                  "additionalProperties": false
+                }
+              },
+              "required": ["file_name", "fieldname_in_file", "interp_method"],
+              "additionalProperties": false
+            }
           },
           "factor": {
             "type": "number"


### PR DESCRIPTION
In the `data_table` schema, `override_file` has been changed from an object to an array-of-objects.