### PR TITLE
Diag and data table schema updates

### DIFF
--- a/FMS/data_table.json
+++ b/FMS/data_table.json
@@ -61,7 +61,8 @@
                       },
                       "source": {
                         "type": "string",
-                        "minLength": 1
+                        "minLength": 1,
+                        "enum": ["fregrid"]
                       }
                     },
                     "required": ["file_name", "source"],

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -87,24 +87,18 @@
             }
           },
           "new_file_freq": {
-            "anyOf": [
-              {"type": "string"}
-            ],
+            "type": "string",
             "pattern": "^(0*[1-9][0-9]* (seconds|minutes|hours|days|months|years), )*0*[1-9][0-9]* (seconds|minutes|hours|days|months|years)$"
           },
           "start_time": {
             "type": "string"
           },
           "file_duration": {
-            "anyOf": [
-              {"type": "string"}
-            ],
+            "type": "string",
             "pattern": "^(0*[1-9][0-9]* (seconds|minutes|hours|days|months|years), )*0*[1-9][0-9]* (seconds|minutes|hours|days|months|years)$"
           },
           "is_ocean": {
-            "anyOf": [
-              {"type": "boolean"}
-            ]
+            "type": "boolean"
           },
           "kind": {
             "type": "string",

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -25,7 +25,7 @@
               {"type": "string"},
               {"type": "number"}
             ],
-            "pattern": "^-[1]{1,1} *[ seconds| minutes| hours| days| months| years]*|^0&|^[1-9]+ [seconds|minutes|hours|days|months|years]{1,1}"
+            "pattern": "^(-1|0|((-1|[0-9]+) +(seconds|minutes|hours|days|months|years)( *, *)?)+)$"
           },
           "time_units": {
             "type": "string",
@@ -87,14 +87,19 @@
             }
           },
           "new_file_freq": {
-            "type": "string",
-            "pattern": "[0-9]{1,} [a-z]{1,}"
+            "anyOf": [
+              {"type": "string"}
+            ],
+            "pattern": "^(0*[1-9][0-9]* (seconds|minutes|hours|days|months|years), )*0*[1-9][0-9]* (seconds|minutes|hours|days|months|years)$"
           },
           "start_time": {
             "type": "string"
           },
           "file_duration": {
-            "type": "string"
+            "anyOf": [
+              {"type": "string"}
+            ],
+            "pattern": "^(0*[1-9][0-9]* (seconds|minutes|hours|days|months|years), )*0*[1-9][0-9]* (seconds|minutes|hours|days|months|years)$"
           },
           "varlist": {
             "type": "array",

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -101,6 +101,11 @@
             ],
             "pattern": "^(0*[1-9][0-9]* (seconds|minutes|hours|days|months|years), )*0*[1-9][0-9]* (seconds|minutes|hours|days|months|years)$"
           },
+          "is_ocean": {
+            "anyOf": [
+              {"type": "boolean"}
+            ]
+          },
           "varlist": {
             "type": "array",
             "items": {

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["title", "base_date"],
   "additionalProperties": false,
@@ -106,11 +106,22 @@
               {"type": "boolean"}
             ]
           },
+          "kind": {
+            "type": "string",
+            "enum": ["r4", "r8", "i4", "i8"]
+          },
+          "module": {
+            "type": "string"
+          },
+          "reduction": {
+            "type": "string",
+            "pattern": "^average$|^min$|^max$|^none$|^rms$|^sum$|^diurnal[1-9]+|^pow[1-9]+"
+          },
           "varlist": {
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["var_name", "reduction", "module", "kind"],
+              "required": ["var_name"],
               "additionalProperties": false,
               "properties": {
                 "kind": {
@@ -144,7 +155,57 @@
               }
             }
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+               "required": ["kind"]
+              },
+            "else": {
+              "properties": {
+                "varlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["kind"]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+               "required": ["module"]
+              },
+            "else": {
+              "properties": {
+                "varlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["module"]
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+               "required": ["reduction"]
+              },
+            "else": {
+              "properties": {
+                "varlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["reduction"]
+                  }
+                }
+              }
+            }
+          }
+        ]
       }
     }
   }


### PR DESCRIPTION
1. Adds `is_ocean` as a valid optional key at the file level
2. Allow `freq: 0` and `freq: -1`
3. Add restrictions to `new_file_freq` and `file_duration`
4. Make the `reduction`, `module`, and `kind` keys optional at the file level. If they are present at the file level, they are optional at the variable level, otherwise they are required. This is needed after https://github.com/NOAA-GFDL/FMS/pull/1545
5. Only allow fregrid as the acceptable source for weight files