### PR TITLE
Add `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+*                    @ceblanton    @J-Lentz
+FMS/diag_table.yaml  @uramirez8707
+FMS/data_table.yaml  @J-Lentz
+FMS/field_table.yaml @J-Lentz


### PR DESCRIPTION
Add a `CODEOWNERS` file which specifies the following:

* Default owners: Chris and Jesse
* `FMS/diag_table.yaml`: Uriel
* `FMS/data_table.yaml`: Jesse
* `FMS/field_table.yaml`: Jesse

Resolves #6.