### PR TITLE
base_date update in the diag_table.yaml

### DIFF
--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -10,7 +10,6 @@
     },
     "base_date": {
       "type": "string",
-      "minLength": 1,
       "anyOf": [
         {"enum": ["$baseDate"]},
         {"pattern": "^([0-9]*[1-9][0-9]* ){3}([0-9]+ ){2}[0-9]+$"}

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -9,13 +9,12 @@
       "minLength": 1
     },
     "base_date": {
-      "type": "array",
-      "minItems": 6,
-      "maxItems": 6,
-      "items": {
-        "type": "integer",
-        "minimum": 0
-      }
+      "type": "string",
+      "minLength": 1,
+      "anyOf": [
+        {"enum": ["$baseDate"]},
+        {"pattern": "^([0-9]*[1-9][0-9]* ){3}([0-9]+ ){2}[0-9]+$"}
+      ]
     },
     "diag_files": {
       "type": "array",


### PR DESCRIPTION
Allow the baste_date to be either
1. A string with 6 positive space separated integers. The first 3 integers (year month day) cannot be 0. The last 3 (min hour second) can be 0. (Thanks @J-Lentz  for the help in getting the regex right)
2. $baseDate