### PR TITLE
diag_table: Add global_meta and attributes rules

### DIFF
--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -45,6 +45,13 @@
             "type": "boolean"
           },
           "global_meta": {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+	    "items": {
+              "type": "object",
+              "additionalProperties": true
+	    }
           },
           "sub_region": {
             "type": "array",
@@ -160,6 +167,13 @@
                   "minLength": 1
                 },
                 "attributes": {
+                  "type": "array",
+                  "minItems": 1,
+                  "maxItems": 1,
+	          "items": {
+                    "type": "object",
+                    "additionalProperties": true
+	          }
                 },
                "zbounds": {
                   "type": "string"

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -50,7 +50,13 @@
             "maxItems": 1,
 	    "items": {
               "type": "object",
-              "additionalProperties": true
+              "additionalProperties": {
+                "oneOf": [
+                  {"type": "string"},
+                  {"type": "number"},
+                  {"type": "boolean"}
+                ]
+              }
 	    }
           },
           "sub_region": {
@@ -172,7 +178,13 @@
                   "maxItems": 1,
 	          "items": {
                     "type": "object",
-                    "additionalProperties": true
+                    "additionalProperties": {
+                      "oneOf": [
+                        {"type": "string"},
+                        {"type": "number"},
+                        {"type": "boolean"}
+		      ]
+		    }
 	          }
                 },
                "zbounds": {


### PR DESCRIPTION
In the diag_table schema, require that the `global_meta` and `attributes` sections each consist of an array containing one (and only one) element, which must be an object. This object contains key/value pairs, the values of which may be strings, numbers or boolean values. Nested structures and null values are not allowed.

Resolves issue #11.