### PR TITLE
Remove confusing duplicate method for specifying pp components

### DIFF
--- a/FRE/fre_pp.json
+++ b/FRE/fre_pp.json
@@ -112,10 +112,6 @@
                 }
               ]
             },
-            "pp_components": {
-              "description": "Space-separated list of user-defined components, discussed in more detail below.",
-              "type": "string"
-            },
             "pp_grid_spec": {
               "description": "Path to FMS grid definition tarfile.",
               "type": "string"
@@ -140,7 +136,6 @@
             "pp_chunk_a",
             "pp_start",
             "pp_stop",
-            "pp_components",
             "pp_grid_spec"
           ],
           "additionalProperties": false
@@ -291,11 +286,15 @@
                            ]
                 },
                 "additionalProperties": false
+              },
+              "switch": {
+                "type": "boolean"
               }
             },
             "required": [
               "type",
-              "sources"
+              "sources",
+              "switch"
             ],
             "additionalProperties": false
           },


### PR DESCRIPTION
We had a list of components to do, and then define the components in the yaml. This is confusing and results in cylc graph problems with a component is listed but not defined.
Instead, set a switch in the component definitions, as a signal to do or not to do.