### PR TITLE
Add conditional dependency

### DIFF
--- a/FRE/fre_pp.json
+++ b/FRE/fre_pp.json
@@ -311,6 +311,9 @@
               "sources",
               "postprocess_on"
             ],
+            "dependentRequired": {
+              "xyInterp": ["inputRealm"]
+            },
             "additionalProperties": false
           },
           "minItems": 1,


### PR DESCRIPTION
- if `xyInterp` defined, `inputRealm` also needs to be defined 