### PR TITLE
Add anchors/modular support

### DIFF
--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -2,7 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["title", "base_date"],
-  "additionalProperties": false,
+  "additionalProperties": {
+    "type": "object"
+  },
   "properties": {
     "title": {
       "type": "string",
@@ -41,9 +43,7 @@
             "type": "string",
             "minLength": 1
           },
-          "write_file": {
-            "type": "boolean"
-          },
+          "write_file": { "type": "boolean" },
           "global_meta": {
             "type": "array",
             "minItems": 1,
@@ -60,9 +60,7 @@
             }
           },
           "sub_region": {
-            "type": "array",
-            "minItems": 1,
-            "maxItems": 1,
+            "type": "object",
             "required": ["grid_type", "corner1", "corner2", "corner3", "corner4"],
             "properties": {
               "grid_type": {
@@ -93,9 +91,7 @@
                 "maxItems": 2,
                 "items": { "type": "number" }
               },
-              "tile": {
-                "type": "number"
-              }
+              "tile": { "type": "number" }
             }
           },
           "new_file_freq": {
@@ -115,9 +111,7 @@
             "type": "string",
             "pattern": "^(0*[1-9][0-9]* (seconds|minutes|hours|days|months|years), )*0*[1-9][0-9]* (seconds|minutes|hours|days|months|years)$"
           },
-          "is_ocean": {
-            "type": "boolean"
-          },
+          "is_ocean": { "type": "boolean" },
           "kind": {
             "type": "string",
             "enum": ["r4", "r8", "i4", "i8"]
@@ -128,8 +122,9 @@
           },
           "reduction": {
             "type": "string",
-            "pattern": "^average$|^min$|^max$|^none$|^rms$|^sum$|^diurnal[1-9]+|^pow[1-9]+"
+            "pattern": "^(average|min|max|none|rms|sum|diurnal[1-9]+|pow[1-9]+)$"
           },
+
           "varlist": {
             "type": "array",
             "items": {
@@ -137,6 +132,10 @@
               "required": ["var_name"],
               "additionalProperties": false,
               "properties": {
+                "var_name": {
+                  "type": "string",
+                  "minLength": 1
+                },
                 "kind": {
                   "type": "string",
                   "enum": ["r4", "r8", "i4", "i8"]
@@ -147,15 +146,9 @@
                 },
                 "reduction": {
                   "type": "string",
-                  "pattern": "^average$|^min$|^max$|^none$|^rms$|^sum$|^diurnal[1-9]+|^pow[1-9]+"
+                  "pattern": "^(average|min|max|none|rms|sum|diurnal[1-9]+|pow[1-9]+)$"
                 },
-                "var_name": {
-                  "type": "string",
-                  "minLength": 1
-                },
-                "write_var": {
-                  "type": "boolean"
-                },
+                "write_var": { "type": "boolean" },
                 "output_name": {
                   "type": "string",
                   "minLength": 1
@@ -164,6 +157,7 @@
                   "type": "string",
                   "minLength": 1
                 },
+                "zbounds": { "type": "string" },
                 "attributes": {
                   "type": "array",
                   "minItems": 1,
@@ -178,62 +172,82 @@
                       ]
                     }
                   }
+                }
+              }
+            }
+          },
+
+          "modules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["module", "varlist"],
+              "additionalProperties": false,
+              "properties": {
+                "module": {
+                  "type": "string",
+                  "minLength": 1
                 },
-                "zbounds": {
-                  "type": "string"
+                "varlist": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["var_name"],
+                    "additionalProperties": false,
+                    "properties": {
+                      "var_name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "kind": {
+                        "type": "string",
+                        "enum": ["r4", "r8", "i4", "i8"]
+                      },
+                      "reduction": {
+                        "type": "string",
+                        "pattern": "^(average|min|max|none|rms|sum|diurnal[1-9]+|pow[1-9]+)$"
+                      },
+                      "write_var": { "type": "boolean" },
+                      "output_name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "long_name": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "zbounds": { "type": "string" },
+                      "attributes": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 1,
+                        "items": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "oneOf": [
+                              { "type": "string" },
+                              { "type": "number" },
+                              { "type": "boolean" }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         },
-        "allOf": [
+
+        "oneOf": [
           {
-            "if": {
-              "required": ["kind"]
-            },
-            "else": {
-              "properties": {
-                "varlist": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["kind"]
-                  }
-                }
-              }
-            }
+            "required": ["varlist"],
+            "not": { "required": ["modules"] }
           },
           {
-            "if": {
-              "required": ["module"]
-            },
-            "else": {
-              "properties": {
-                "varlist": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["module"]
-                  }
-                }
-              }
-            }
-          },
-          {
-            "if": {
-              "required": ["reduction"]
-            },
-            "else": {
-              "properties": {
-                "varlist": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["reduction"]
-                  }
-                }
-              }
-            }
+            "required": ["modules"],
+            "not": { "required": ["varlist"] }
           }
         ]
       }

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -51,11 +51,7 @@
             "items": {
               "type": "object",
               "additionalProperties": {
-                "oneOf": [
-                  { "type": "string" },
-                  { "type": "number" },
-                  { "type": "boolean" }
-                ]
+                "type": ["string", "number", "boolean"]
               }
             }
           },
@@ -165,11 +161,7 @@
                   "items": {
                     "type": "object",
                     "additionalProperties": {
-                      "oneOf": [
-                        { "type": "string" },
-                        { "type": "number" },
-                        { "type": "boolean" }
-                      ]
+                      "type": ["string", "number", "boolean"]
                     }
                   }
                 }

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -11,8 +11,8 @@
     "base_date": {
       "type": "string",
       "anyOf": [
-        {"enum": ["$baseDate"]},
-        {"pattern": "^([0-9]*[1-9][0-9]* ){3}([0-9]+ ){2}[0-9]+$"}
+        { "enum": ["$baseDate"] },
+        { "pattern": "^([0-9]*[1-9][0-9]* ){3}([0-9]+ ){2}[0-9]+$" }
       ]
     },
     "diag_files": {
@@ -28,8 +28,8 @@
           },
           "freq": {
             "anyOf": [
-              {"type": "string"},
-              {"type": "number"}
+              { "type": "string" },
+              { "type": "number" }
             ],
             "pattern": "^(-1|0|((-1|[0-9]+) +(seconds|minutes|hours|days|months|years)( *, *)?)+)$"
           },
@@ -48,16 +48,16 @@
             "type": "array",
             "minItems": 1,
             "maxItems": 1,
-	    "items": {
+            "items": {
               "type": "object",
               "additionalProperties": {
                 "oneOf": [
-                  {"type": "string"},
-                  {"type": "number"},
-                  {"type": "boolean"}
+                  { "type": "string" },
+                  { "type": "number" },
+                  { "type": "boolean" }
                 ]
               }
-	    }
+            }
           },
           "sub_region": {
             "type": "array",
@@ -73,33 +73,25 @@
                 "type": "array",
                 "minItems": 2,
                 "maxItems": 2,
-                "items": {
-                  "type": "number"
-                }
+                "items": { "type": "number" }
               },
               "corner2": {
                 "type": "array",
                 "minItems": 2,
                 "maxItems": 2,
-                "items": {
-                  "type": "number"
-                }
+                "items": { "type": "number" }
               },
               "corner3": {
                 "type": "array",
                 "minItems": 2,
                 "maxItems": 2,
-                "items": {
-                  "type": "number"
-                }
+                "items": { "type": "number" }
               },
               "corner4": {
                 "type": "array",
                 "minItems": 2,
                 "maxItems": 2,
-                "items": {
-                  "type": "number"
-                }
+                "items": { "type": "number" }
               },
               "tile": {
                 "type": "number"
@@ -176,18 +168,18 @@
                   "type": "array",
                   "minItems": 1,
                   "maxItems": 1,
-	          "items": {
+                  "items": {
                     "type": "object",
                     "additionalProperties": {
                       "oneOf": [
-                        {"type": "string"},
-                        {"type": "number"},
-                        {"type": "boolean"}
-		      ]
-		    }
-	          }
+                        { "type": "string" },
+                        { "type": "number" },
+                        { "type": "boolean" }
+                      ]
+                    }
+                  }
                 },
-               "zbounds": {
+                "zbounds": {
                   "type": "string"
                 }
               }
@@ -197,8 +189,8 @@
         "allOf": [
           {
             "if": {
-               "required": ["kind"]
-              },
+              "required": ["kind"]
+            },
             "else": {
               "properties": {
                 "varlist": {
@@ -213,8 +205,8 @@
           },
           {
             "if": {
-               "required": ["module"]
-              },
+              "required": ["module"]
+            },
             "else": {
               "properties": {
                 "varlist": {
@@ -229,8 +221,8 @@
           },
           {
             "if": {
-               "required": ["reduction"]
-              },
+              "required": ["reduction"]
+            },
             "else": {
               "properties": {
                 "varlist": {


### PR DESCRIPTION
The schema was updated to:
1. allow for anchors to be defined at the top of the yaml (see https://github.com/NOAA-GFDL/FMS/issues/1677)
2. allow for diag_files to define modules with a varlist or a varlist at the file level (see https://github.com/NOAA-GFDL/FMS/issues/1678)

This is backwards compatible, so this schema will work not break any current yamls 