### PR TITLE
Change `envSetup`

### DIFF
--- a/FRE/fre_make.json
+++ b/FRE/fre_make.json
@@ -170,8 +170,8 @@
                     "description": "The compiler used to build the model",
                     "type": "string"
                 },
-                "env_setup": {
-                    "description": "Array of bash commands to initialize modules, load modules, and unload modules",
+                "envSetup": {
+                    "description": "Array of additional shell commands needed to compile the model. Can be used to initialize modules, load modules, and unload modules",
                     "type": "array",
                     "items": {"type": "string"}
                 },

--- a/FRE/fre_make.json
+++ b/FRE/fre_make.json
@@ -171,7 +171,7 @@
                     "type": "string"
                 },
                 "env_setup": {
-                    "description": "Array of commands to initialize modules, load modules, and unload modules",
+                    "description": "Array of bash commands to initialize modules, load modules, and unload modules",
                     "type": "array",
                     "items": {"type": "string"}
                 },

--- a/FRE/fre_make.json
+++ b/FRE/fre_make.json
@@ -170,13 +170,8 @@
                     "description": "The compiler used to build the model",
                     "type": "string"
                 },
-                "modulesInit": {
-                    "description": "Array of commands to run before loading modules",
-                    "type": "array",
-                    "items": {"type": "string"}
-                },
-                "modules": {
-                    "description": "List (array) of modules to load",
+                "env_setup": {
+                    "description": "Array of commands to initialize modules, load modules, and unload modules",
                     "type": "array",
                     "items": {"type": "string"}
                 },


### PR DESCRIPTION
Replaces `modules` and `modulesInit` with `envSetup` to create a list of commands to initialize, load, and unload any modules.