### PR TITLE
 Make `postprocess_on` and `analysis_on` optional

### DIFF
--- a/FRE/fre_pp.json
+++ b/FRE/fre_pp.json
@@ -146,10 +146,6 @@
             "do_analysis": {
               "description": "Switch to launch analysis scripts",
               "type": "boolean"
-            },
-            "do_analysis_only": {
-              "description": "Switch to only launch analysis scripts",
-              "type": "boolean"
             }
           },
           "required": [

--- a/FRE/fre_pp.json
+++ b/FRE/fre_pp.json
@@ -142,10 +142,6 @@
             "do_atmos_plevel_masking": {
               "description": "Switch to mask atmos pressure-level output above/below surface pressure/atmos top.",
               "type": "boolean"
-            },
-            "do_analysis": {
-              "description": "Switch to launch analysis scripts",
-              "type": "boolean"
             }
           },
           "required": [

--- a/FRE/fre_pp.json
+++ b/FRE/fre_pp.json
@@ -154,9 +154,7 @@
           },
           "required": [
             "clean_work",
-            "do_atmos_plevel_masking",
-            "do_analysis",
-            "do_analysis_only"
+            "do_atmos_plevel_masking"
           ],
           "additionalProperties": false
         },

--- a/FRE/fre_pp.json
+++ b/FRE/fre_pp.json
@@ -279,13 +279,13 @@
                 "additionalProperties": false
               },
               "postprocess_on": {
-                "type": "boolean"
+                "type": "boolean",
+                "default": "True"
               }
             },
             "required": [
               "type",
-              "sources",
-              "postprocess_on"
+              "sources"
             ],
             "dependentRequired": {
               "xyInterp": ["inputRealm", "sourceGrid", "interpMethod"]
@@ -461,15 +461,15 @@
                   "pattern": "^P[0-9]+[M|Y]$"
                 },
                 "analysis_on": {
-                  "type": "boolean"
+                  "type": "boolean",
+                  "default": "True"
                 }
               },
               "required": [
                 "components",
                 "script_type",
                 "product",
-                "chunk_size",
-                "analysis_on"
+                "chunk_size"
               ]
             }
           },


### PR DESCRIPTION
- users can define these keys in the YAML if they want to make them False
- otherwise, if they are not explicitly defined, the default would be True
- still have the option of defining `postprocess_on: True` or `analysis_on: True` since they are optional though 