### PR TITLE
Schema updates for the corner subregion keys + reduction and kind keys

### DIFF
--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -69,19 +69,19 @@
                 },
                 "corner1": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? *, *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
                 },
                 "corner2": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? *, *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
                 },
                 "corner3": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? *, *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
                 },
                 "corner4": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? *, *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
                 },
                 "tile": { "type": "number" }
               }
@@ -228,15 +228,60 @@
             }
           }
         },
-
-        "oneOf": [
+        "allOf": [
           {
-            "required": ["varlist"],
-            "not": { "required": ["modules"] }
+            "oneOf": [
+              {
+                "required": ["varlist"],
+                "not": { "required": ["modules"] }
+              },
+              {
+                "required": ["modules"],
+                "not": { "required": ["varlist"] }
+              }
+            ]
           },
           {
-            "required": ["modules"],
-            "not": { "required": ["varlist"] }
+            "anyOf": [
+              { "required": ["kind"] },
+              {
+                "properties": {
+                  "varlist": {
+                    "items": { "required": ["kind"] }
+                  },
+                  "modules": {
+                    "items": {
+                      "properties": {
+                        "varlist": {
+                          "items": { "required": ["kind"] }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          {
+            "anyOf": [
+              { "required": ["reduction"] },
+              {
+                "properties": {
+                  "varlist": {
+                    "items": { "required": ["reduction"] }
+                  },
+                  "modules": {
+                    "items": {
+                      "properties": {
+                        "varlist": {
+                          "items": { "required": ["reduction"] }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ]
           }
         ]
       }

--- a/FMS/diag_table.json
+++ b/FMS/diag_table.json
@@ -69,19 +69,19 @@
                 },
                 "corner1": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? -?\\d+(\\.\\d+)?$"
                 },
                 "corner2": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? -?\\d+(\\.\\d+)?$"
                 },
                 "corner3": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? -?\\d+(\\.\\d+)?$"
                 },
                 "corner4": {
                   "type": "string",
-                  "pattern": "^-?\\d+(\\.\\d+)? * *-?\\d+(\\.\\d+)?$"
+                  "pattern": "^-?\\d+(\\.\\d+)? -?\\d+(\\.\\d+)?$"
                 },
                 "tile": { "type": "number" }
               }
@@ -150,7 +150,10 @@
                   "type": "string",
                   "minLength": 1
                 },
-                "zbounds": { "type": "string" },
+                "zbounds": {
+                  "type": "string",
+                  "pattern": "^-?\\d+(\\.\\d+)? -?\\d+(\\.\\d+)?$"
+                },
                 "attributes": {
                   "type": "array",
                   "minItems": 1,


### PR DESCRIPTION
Updates schema so that it:
  1) only accepts space in the corner keys - https://github.com/NOAA-GFDL/fms_yaml_tools/issues/85
  2) forces the reduction and kind to be specified in either the diag_file level or the variable level - https://github.com/NOAA-GFDL/fms_yaml_tools/issues/87